### PR TITLE
Fix youtube-dl command in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ chromecast --host 192.168.1.100 play http://192.168.1.1/media/song.mp3
 Play a Youtube video (courtesy of [youtube-dl](https://www.npmjs.com/package/youtube-dl) package)
 
 ```
-chromecast --host 192.168.1.100 play (youtube-dl --get-url "https://www.youtube.com/watch?v=WI4-HUn8dFc")
+chromecast --host 192.168.1.100 play $(youtube-dl -f bestaudio --get-url "https://youtu.be/dQw4w9WgXcQ")
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ chromecast --host 192.168.1.100 play http://192.168.1.1/media/song.mp3
 Play a Youtube video (courtesy of [youtube-dl](https://www.npmjs.com/package/youtube-dl) package)
 
 ```
-chromecast --host 192.168.1.100 play $(youtube-dl -f bestaudio --get-url "https://youtu.be/dQw4w9WgXcQ")
+chromecast --host 192.168.1.100 play $(youtube-dl --format bestaudio --get-url "https://youtu.be/dQw4w9WgXcQ")
 ```
 
 ## Features


### PR DESCRIPTION
1. Fixes the command replacement to support most command lines
2. Adds flag to only get the audio feed
3. Uses shorter youtu.be URL
4. Uses better example video 🎷